### PR TITLE
Fix: remove siteadmin and siteGuestRecordDefaultOwner as hardcoded user in Coral_Cloud.site-meta.xml

### DIFF
--- a/cc-site/main/default/sites/Coral_Cloud.site-meta.xml
+++ b/cc-site/main/default/sites/Coral_Cloud.site-meta.xml
@@ -25,9 +25,6 @@
     <referrerPolicyOriginWhenCrossOrigin
     >true</referrerPolicyOriginWhenCrossOrigin>
     <selfRegPage>CommunitiesSelfReg</selfRegPage>
-    <siteAdmin>test-cjmvyzld0cn6@example.com</siteAdmin>
-    <siteGuestRecordDefaultOwner
-    >test-cjmvyzld0cn6@example.com</siteGuestRecordDefaultOwner>
     <siteType>ChatterNetwork</siteType>
     <urlPathPrefix>coralcloud</urlPathPrefix>
 </CustomSite>


### PR DESCRIPTION
### What does this PR do?

This PR removed siteadmin and siteGuestRecordDefaultOwner reference to a scratch org user which makes the deployments fail

### What issues does this PR fix or reference?

## The PR fulfills these requirements:

[ ] Tests for the proposed changes have been added/updated.
[ ] Code linting and formatting was performed.

### Functionality Before

If you were to deploy the cc-site the deployment will fail with the error: "User does not exists" as this user is specific to the scratch org where the development was done. Simply by removing the reference, it fixes the issue.

### Functionality After

<insert gif and/or summary>
