### PR TITLE
fix: rename default agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you need to [update the Salesforce CLI](https://developer.salesforce.com/docs
 
 1. From **Setup**, go to **Einstein Setup** and click **Turn on Einstein**.
 
-1. From **Setup**, go to **Agents** and toggle on **Einstein Copilot for Salesforce**. You may need to refresh the page to see the Agents menu after turning on Einstein.
+1. From **Setup**, go to **Agents** and toggle on **Agentforce**. You may need to refresh the page to see the Agents menu after turning on Einstein.
 
 1. From **Setup**, go to **Einstein for Sales** and ensure that **Turn on Sales Emails** is toggled on.
 

--- a/cc-employee-app/main/default/bots/Copilot_for_Salesforce/Copilot_for_Salesforce.bot-meta.xml
+++ b/cc-employee-app/main/default/bots/Copilot_for_Salesforce/Copilot_for_Salesforce.bot-meta.xml
@@ -2,11 +2,11 @@
 <Bot xmlns="http://soap.sforce.com/2006/04/metadata">
     <agentType>Employee</agentType>
     <botMlDomain>
-        <label>Einstein Copilot</label>
+        <label>Agentforce (Default)</label>
         <name>Copilot_for_Salesforce</name>
     </botMlDomain>
     <description>An AI assistant for in-org business tasks.</description>
-    <label>Einstein Copilot</label>
+    <label>Agentforce (Default)</label>
     <logPrivateConversationData>false</logPrivateConversationData>
     <pageContextVariables>
         <dataType>Text</dataType>


### PR DESCRIPTION
### What does this PR do?

Updates "Copilot" term to "Agentforce".
