### PR TITLE
ci: stage employee-app deploy to satisfy prompt-template dependencies

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -204,6 +204,11 @@ jobs:
             - name: 'Assign Prompt Template Manager permission set'
               run: sf org assign permset -n EinsteinGPTPromptTemplateManager
 
+            # Deploy prompt templates first so components that reference them
+            # (FlexiPage, Flow) can resolve the templates during their own deploy
+            - name: 'Push prompt templates to scratch org'
+              run: sf project deploy start -d cc-employee-app/main/default/genAiPromptTemplates
+
             # Push employee source to scratch org
             - name: 'Push employee source to scratch org'
               run: sf project deploy start -d cc-employee-app

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -204,10 +204,11 @@ jobs:
             - name: 'Assign Prompt Template Manager permission set'
               run: sf org assign permset -n EinsteinGPTPromptTemplateManager
 
-            # Deploy prompt templates first so components that reference them
-            # (FlexiPage, Flow) can resolve the templates during their own deploy
-            - name: 'Push prompt templates to scratch org'
-              run: sf project deploy start -d cc-employee-app/main/default/genAiPromptTemplates
+            # Deploy Apex classes first so prompt templates can resolve their
+            # Apex data providers (e.g. apex://PersonalizedGuestExperiences)
+            # when they deploy as part of the full employee app
+            - name: 'Push employee Apex classes to scratch org'
+              run: sf project deploy start -d cc-employee-app/main/default/classes
 
             # Push employee source to scratch org
             - name: 'Push employee source to scratch org'

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -204,11 +204,17 @@ jobs:
             - name: 'Assign Prompt Template Manager permission set'
               run: sf org assign permset -n EinsteinGPTPromptTemplateManager
 
-            # Deploy Apex classes first so prompt templates can resolve their
-            # Apex data providers (e.g. apex://PersonalizedGuestExperiences)
-            # when they deploy as part of the full employee app
+            # Staged deploy to satisfy prompt-template dependencies:
+            # 1. Apex classes — prompt templates resolve their Apex data
+            #    providers (e.g. apex://PersonalizedGuestExperiences)
+            # 2. Prompt templates — must be committed before the FlexiPage
+            #    and Flow that reference them can be validated
+            # 3. Full employee app — remaining components now resolve
             - name: 'Push employee Apex classes to scratch org'
               run: sf project deploy start -d cc-employee-app/main/default/classes
+
+            - name: 'Push prompt templates to scratch org'
+              run: sf project deploy start -d cc-employee-app/main/default/genAiPromptTemplates
 
             # Push employee source to scratch org
             - name: 'Push employee source to scratch org'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,11 +144,17 @@ jobs:
             - name: 'Assign Prompt Template Manager permission set'
               run: sf org assign permset -n EinsteinGPTPromptTemplateManager
 
-            # Deploy Apex classes first so prompt templates can resolve their
-            # Apex data providers (e.g. apex://PersonalizedGuestExperiences)
-            # when they deploy as part of the full employee app
+            # Staged deploy to satisfy prompt-template dependencies:
+            # 1. Apex classes — prompt templates resolve their Apex data
+            #    providers (e.g. apex://PersonalizedGuestExperiences)
+            # 2. Prompt templates — must be committed before the FlexiPage
+            #    and Flow that reference them can be validated
+            # 3. Full employee app — remaining components now resolve
             - name: 'Push employee Apex classes to scratch org'
               run: sf project deploy start -d cc-employee-app/main/default/classes
+
+            - name: 'Push prompt templates to scratch org'
+              run: sf project deploy start -d cc-employee-app/main/default/genAiPromptTemplates
 
             # Push employee source to scratch org
             - name: 'Push employee source to scratch org'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,11 @@ jobs:
             - name: 'Assign Prompt Template Manager permission set'
               run: sf org assign permset -n EinsteinGPTPromptTemplateManager
 
+            # Deploy prompt templates first so components that reference them
+            # (FlexiPage, Flow) can resolve the templates during their own deploy
+            - name: 'Push prompt templates to scratch org'
+              run: sf project deploy start -d cc-employee-app/main/default/genAiPromptTemplates
+
             # Push employee source to scratch org
             - name: 'Push employee source to scratch org'
               run: sf project deploy start -d cc-employee-app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,10 +144,11 @@ jobs:
             - name: 'Assign Prompt Template Manager permission set'
               run: sf org assign permset -n EinsteinGPTPromptTemplateManager
 
-            # Deploy prompt templates first so components that reference them
-            # (FlexiPage, Flow) can resolve the templates during their own deploy
-            - name: 'Push prompt templates to scratch org'
-              run: sf project deploy start -d cc-employee-app/main/default/genAiPromptTemplates
+            # Deploy Apex classes first so prompt templates can resolve their
+            # Apex data providers (e.g. apex://PersonalizedGuestExperiences)
+            # when they deploy as part of the full employee app
+            - name: 'Push employee Apex classes to scratch org'
+              run: sf project deploy start -d cc-employee-app/main/default/classes
 
             # Push employee source to scratch org
             - name: 'Push employee source to scratch org'


### PR DESCRIPTION
## Problem

`scratch-org-test` began failing at the **Push employee source to scratch org** step (`sf project deploy start -d cc-employee-app`) with two component failures:

| Type | Name | Problem |
|------|------|---------|
| FlexiPage | `Experience_Record_Page` | `Generate_Guest_Reviews_Summary` isn't a valid value for Generative Prompt Template |
| Flow | `PersonalizedSchedule` | invalid reference to `Generate_Personalized_Schedule.promptResponse` |

### Why now?
Not caused by any repo change. `scratch-org-test` is skipped on Dependabot PRs and only runs on push to `main`; the employee-app metadata was unchanged since the v65 upgrade. This is **platform drift** — the platform now validates GenAiPromptTemplate dependencies at deploy time, and the whole `cc-employee-app` used to deploy in a single transaction.

### Root cause (established via CI)
The employee app can no longer deploy as one transaction because of a dependency chain the deploy can't self-order:
1. The `Generate_Personalized_Schedule` **prompt template** has an Apex **data provider** (`apex://PersonalizedGuestExperiences`) that must exist first — deploying templates alone fails with *"We can't find the related records for the prompt template [apex://PersonalizedGuestExperiences]"*.
2. The **FlexiPage** and **Flow** reference the prompt templates, which must be committed before those consumers validate.

## Fix
Stage the deploy so each dependency is committed before its consumer:
1. Apex classes → 2. prompt templates → 3. full `cc-employee-app`.

Applied to both `ci.yml` (push to main) and `ci-pr.yml` (pull requests).

## Verification
This PR's `scratch-org-test` run passes end-to-end (full scratch-org deploy + Apex tests). The staged ordering was arrived at empirically from the failures each intermediate attempt surfaced.

## Note for maintainers
Real users deploying `cc-employee-app` in one shot will hit the same ordering issue — the staged deploy likely belongs in the setup instructions / install script too. Flagging for your call; out of scope for this CI fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)